### PR TITLE
Terminate function fix.

### DIFF
--- a/common_apps/mzbench_language/src/mzbl_interpreter.erl
+++ b/common_apps/mzbench_language/src/mzbl_interpreter.erl
@@ -7,24 +7,36 @@
 eval_std(Expr, Env) ->
     {Res, _} = eval(Expr, undefined, Env, undefined),
     Res.
-
 -spec eval(script_expr(), worker_state(), worker_env(), module())
     -> {script_value(), worker_state()}.
-eval(#operation{is_std = false, name = Name, args = Args, meta = Meta}, State, Env, WorkerProvider) ->
+    %% Generates exception: error:{mzbl_interpreter_runtime_error, {{Error, _Reason}, State }}
+eval(Expr, State, Env, WorkerProvider) ->
+    try
+        eval_(Expr, State, Env, WorkerProvider)
+    catch
+        error:{mzbl_interpreter_runtime_error, {{Error, _Reason}, State }} = E ->
+            erlang:raise(Error, E, erlang:get_stacktrace());
+        E:R ->
+            erlang:raise(error, {mzbl_interpreter_runtime_error, {{E, R}, State}}, erlang:get_stacktrace())
+    end.
+
+-spec eval_(script_expr(), worker_state(), worker_env(), module())
+    -> {script_value(), worker_state()}.
+eval_(#operation{is_std = false, name = Name, args = Args, meta = Meta}, State, Env, WorkerProvider) ->
     eval_function(Name, Args, Meta, State, Env, WorkerProvider);
-eval(#operation{is_std = true, name = Name, args = Args, meta = Meta}, State, Env, WorkerProvider) ->
+eval_(#operation{is_std = true, name = Name, args = Args, meta = Meta}, State, Env, WorkerProvider) ->
     eval_std_function(Name, Args, Meta, State, Env, WorkerProvider);
-eval(ExprList, State, Env, WorkerProvider) when is_list(ExprList) ->
+eval_(ExprList, State, Env, WorkerProvider) when is_list(ExprList) ->
     lists:foldl(fun(E, {EvaluatedParams, CurrentState}) ->
                     {Result, S} = eval(E, CurrentState, Env, WorkerProvider),
                     {EvaluatedParams ++ [Result], S}
               end,
               {[], State},
               ExprList);
-eval(#constant{value=V} = C, State, Env,  WorkerProvider) -> 
+eval_(#constant{value=V} = C, State, Env,  WorkerProvider) ->
     {Value, NewState} = eval(V, State, Env, WorkerProvider),
     {C#constant{value=Value}, NewState};
-eval(Value, State, _Env,  _) -> {Value, State}.
+eval_(Value, State, _Env,  _) -> {Value, State}.
 
 eval_function(Name, [], Meta, State, _, WorkerProvider) ->
     WorkerProvider:apply(Name, [], State, Meta);

--- a/node/apps/mzbench/src/mzb_pool.erl
+++ b/node/apps/mzbench/src/mzb_pool.erl
@@ -265,7 +265,10 @@ maybe_report_error(_, {ok, _}) -> ok;
 maybe_report_error(Pid, {error, Reason}) ->
     system_log:error("Worker ~p has finished abnormally: ~p", [Pid, Reason]);
 maybe_report_error(Pid, {exception, Node, {_C, E, ST}}) ->
-    system_log:error("Worker ~p on ~p has crashed: ~p~nStacktrace: ~p", [Pid, Node, E, ST]).
+    system_log:error("Worker ~p on ~p has crashed: ~p~nStacktrace: ~p", [Pid, Node, E, ST]);
+maybe_report_error(Pid, {exception, Node, {_C, E, ST, WorkerState}}) ->
+    system_log:error("Worker ~p on ~p has crashed: ~p~nStacktrace: ~p~nState of worker: ~p", [Pid, Node, E, ST, WorkerState]).
+
 
 sleep_off(StartTime, ShouldBe) ->
     Current = msnow() - StartTime,

--- a/node/apps/mzbench/src/mzb_worker_runner.erl
+++ b/node/apps/mzbench/src/mzb_worker_runner.erl
@@ -8,27 +8,37 @@
     -> ok.
 run_worker_script(Script, Env, {WorkerProvider, Worker}, PoolPid, PoolName) ->
     %NodeName = mzb_utility:hostname_str(node()),
-    Res =
-        try
-            _ = random:seed(now()),
-            ok = mzb_metrics:notify(mzb_string:format("workers.~s.started", [PoolName]), 1),
-            %ok = mzb_metrics:notify(mzb_string:format("workers.~s.~s.started", [PoolName, NodeName]), 1),
-
-            InitialState = WorkerProvider:init(Worker),
-            {WorkerResult, WorkerResultState} = mzbl_interpreter:eval(Script, InitialState, Env, WorkerProvider),
-            ok = mzb_metrics:notify(mzb_string:format("workers.~s.ended", [PoolName]), 1),
-            %ok = mzb_metrics:notify(mzb_string:format("workers.~s.~s.ended", [PoolName, NodeName]), 1),
-            _ = (catch  WorkerProvider:terminate(WorkerResult, WorkerResultState)),
-            {ok, WorkerResult}
-        catch
-            C:E ->
-                ST = erlang:get_stacktrace(),
-                ok = mzb_metrics:notify(mzb_string:format("workers.~s.ended", [PoolName]), 1),
-                ok = mzb_metrics:notify(mzb_string:format("workers.~s.failed", [PoolName]), 1),
-                _ = (catch WorkerProvider:terminate({C, E, ST}, undefined)),
+    Res = try
+        _ = random:seed(now()),
+        ok = mzb_metrics:notify(mzb_string:format("workers.~s.started", [PoolName]), 1),
+        InitialState = WorkerProvider:init(Worker),
+        {WorkerResult, WorkerResultState} = mzbl_interpreter:eval(Script, InitialState, Env, WorkerProvider),
+        WorkerProvider:terminate(WorkerResult, { Worker, WorkerResultState}),
+        {ok, WorkerResult}
+    catch
+        error:{mzbl_interpreter_runtime_error, {{Error, Reason}, ErrorState }} ->
+            ST = erlang:get_stacktrace(),
+            ok = mzb_metrics:notify(mzb_string:format("workers.~s.failed", [PoolName]), 1),
+            try
+                WorkerProvider:terminate({ Error, Reason, ST }, { Worker, ErrorState}),
+                {exception, node(),  { Error, Reason, ST, ErrorState }}
+            catch
+                E0:R0 ->
+                    {exception, node(), { E0, R0, erlang:get_stacktrace() }}
+            end;
+        C:E ->
+            ST = erlang:get_stacktrace(),
+            ok = mzb_metrics:notify(mzb_string:format("workers.~s.failed", [PoolName]), 1),
+            try
+                WorkerProvider:terminate({C, E, ST}, { Worker, undefined}),
                 {exception, node(), {C, E, ST}}
-        end,
-
+            catch
+                E1:R1 ->
+                    {exception, node(), { E1, R1, erlang:get_stacktrace() }}
+            end
+    after
+            mzb_metrics:notify(mzb_string:format("workers.~s.ended", [PoolName]), 1)
+    end,
     PoolPid ! {worker_result, self(), Res},
     ok.
 


### PR DESCRIPTION
I found that terminate callback never called, because it has mistake inside mzb_worker_runner.
So i fixed it and made that terminate function will be called always when worker crashed and when worker  finished his work.

This PR related with #88 